### PR TITLE
1.1.9

### DIFF
--- a/SecurityComplianceCenter/SecurityComplianceCenter.psd1
+++ b/SecurityComplianceCenter/SecurityComplianceCenter.psd1
@@ -3,7 +3,7 @@
 	RootModule	      = 'SecurityComplianceCenter.psm1'
 	
 	# Version number of this module.
-	ModuleVersion	  = '1.1.4'
+	ModuleVersion	  = '1.1.8'
 	
 	# ID used to uniquely identify this module
 	GUID			  = '86d8860e-52a8-48f7-a5eb-f1ba7cded2bc'
@@ -42,6 +42,7 @@
 	# Functions to export from this module
 	FunctionsToExport = @(
 		'Connect-SCC'
+		'Enable-SccAuthentication'
 		'Get-SccLabelLocalization'
 		'Import-SccLabelLocalizationXml'
 		'Set-SccLabelLocalization'

--- a/SecurityComplianceCenter/SecurityComplianceCenter.psd1
+++ b/SecurityComplianceCenter/SecurityComplianceCenter.psd1
@@ -3,7 +3,7 @@
 	RootModule	      = 'SecurityComplianceCenter.psm1'
 	
 	# Version number of this module.
-	ModuleVersion	  = '1.1.8'
+	ModuleVersion	  = '1.1.9'
 	
 	# ID used to uniquely identify this module
 	GUID			  = '86d8860e-52a8-48f7-a5eb-f1ba7cded2bc'

--- a/SecurityComplianceCenter/changelog.md
+++ b/SecurityComplianceCenter/changelog.md
@@ -1,5 +1,12 @@
 ﻿# Changelog
 
+## 1.1.8 (2020-05-13)
+
+- New: Command Enable-SccAuthentication - configures WinRM to allow modern authentication when policies forbid the use of basic authentication.
+- Upd: Import-SccLabelLocalizationXml - added validation for invalid characters among the imported XML.
+- Upd: Set-SccLabelLocalization - added input validation for invalid characters
+- Upd: Connect-SCC - added detection for disabled basic auth in WinRM client
+
 ## 1.1.4 (2020-05-04)
 
 - Fix: Import-SccLabelLocalizationXml - invalid parameter on Stop-PSFFunction causes unexpected errors without proper handling

--- a/SecurityComplianceCenter/changelog.md
+++ b/SecurityComplianceCenter/changelog.md
@@ -1,10 +1,11 @@
 ﻿# Changelog
 
-## 1.1.8 (2020-05-13)
+## 1.1.9 (2020-05-13)
 
 - New: Command Enable-SccAuthentication - configures WinRM to allow modern authentication when policies forbid the use of basic authentication.
 - Upd: Import-SccLabelLocalizationXml - added validation for invalid characters among the imported XML.
 - Upd: Set-SccLabelLocalization - added input validation for invalid characters
+- Upd: Set-SccLabelLocalization - adding a new language to either displayname or tooltip will add the default text to the other language if needed. SCC requries languages to have both entries filled if ANY tooltip has been defined.
 - Upd: Connect-SCC - added detection for disabled basic auth in WinRM client
 
 ## 1.1.4 (2020-05-04)

--- a/SecurityComplianceCenter/en-us/strings.psd1
+++ b/SecurityComplianceCenter/en-us/strings.psd1
@@ -1,19 +1,26 @@
 ﻿# This is where the strings go, that are written by
 # Write-PSFMessage, Stop-PSFFunction or the PSFramework validation scriptblocks
 @{
-	'Import-SccLabelLocalizationXml.Content.BadDocument' = 'Not an export file from AIP: {0}' # $fileItem
-	'Import-SccLabelLocalizationXml.Content.Error'       = 'Not a legal XML document: {0}' # $fileItem
-	'Import-SccLabelLocalizationXml.DisplayName.TooLong' = 'Too long displayname detected for {0} in language {1} | {2} | The maximum length is 64 characters, this displayname cannot be imported! Specified string: {3}' # ($entry.ID -split "/")[-2], $language, $entry.defaultText, $entry.LocalizedText
-	'Import-SccLabelLocalizationXml.InvalidPath.Error'   = 'Not a legal filesystem path: {0}' # $pathItem
-	'Import-SccLabelLocalizationXml.Processing'          = 'Processing localization data from {0}' # $fileItem
-	'Import-SccLabelLocalizationXml.Tooltip.TooLong'     = 'Too long tooltip detected for {0} in language {1} | {2} | The maximum length is 1000 characters, this tooltip cannot be imported! Specified string: {3}' # ($entry.ID -split "/")[-2], $language, $entry.defaultText, $entry.LocalizedText
-	'Set-SccLabelLocalization.Label.NoIdentity.Error'    = 'No label identity was specified. Please specify at least one of "-Name", "-FriendlyName" or "-Identity"' # 
-	'Set-SccLabelLocalization.Label.NotFound.Error'      = 'No label was found that matched: {0} | {1} | {2}' # $Name, $FriendlyName, $Identity
-	'Set-SccLabelLocalization.Processing'                = 'Processing localization update for {0}' # $targetLabel.FriendlyName
-	'Set-SccLabelLocalization.Skipping.AlreadySet'       = 'Skipping update to {0}, as "-Default" was specified and {1} > {2} is already set' # $targetLabel.FriendlyName, $Type, $Language
-	'Set-SccLabelLocalization.Text.DisplayName.TooLong'  = 'The specified displayname for {0} ({1}) is too long. Maximum length is 64 characters. Text specified: {2}' # $targetLabel.FriendlyName, $Language, $Text
-	'Set-SccLabelLocalization.Text.Tooltip.TooLong'      = 'The specified tooltip for {0} ({1}) is too long. Maximum length is 1000 characters. Text specified: {2}' # $targetLabel.FriendlyName, $Language, $Text
-	'Set-SccLabelLocalization.Updating'                  = 'Updating {1} in language {2} on {0}' # $targetLabel.FriendlyName, $Type, $Language
-	'Set-SccLabelLocalization.Updating.Bulk'             = 'Executing bulk update of all localization changes to {0}' # $labelObject.FriendlyName
-	'Set-SccLabelLocalization.Updating.Bulk.Failed'      = 'Failed to update localization settings on {0}' # $labelObject.FriendlyName
+	'Connect-SCC.Basic.Disabled'                               = 'Cannot connect to SCC: Local client policies prevent the use of PowerShell remoting with Modern Authentication! This happens when a Group Policy prevents the use of Basic Authentication for Clients - WinRM does not know the difference between basic authentication and modern authentication. To enable the ability to connect, use "Enable-SccAuthentication" from a console ran "As Administrator"' # 
+	'Enable-SccAuthentication.Enabling'                        = 'Enabling Modern Authentication for PowerShell Remoting' # 
+	'Enable-SccAuthentication.NotElevated'                     = 'This command requires elevation. Please start a new console "As Administrator"' # 
+	'Import-SccLabelLocalizationXml.Content.BadDocument'       = 'Not an export file from AIP: {0}' # $fileItem
+	'Import-SccLabelLocalizationXml.Content.Error'             = 'Not a legal XML document: {0}' # $fileItem
+	'Import-SccLabelLocalizationXml.DisplayName.BadCharacters' = 'Bad character detected for {0} in language {1}: {2} | {3} | This will prevent its application. Specified string: {4}' # ($entry.ID -split "/")[-2], $language, ($characters -join ","), $entry.defaultText, $entry.LocalizedText
+	'Import-SccLabelLocalizationXml.DisplayName.TooLong'       = 'Too long displayname detected for {0} in language {1} | {2} | The maximum length is 64 characters, this displayname cannot be imported! Specified string: {3}' # ($entry.ID -split "/")[-2], $language, $entry.defaultText, $entry.LocalizedText
+	'Import-SccLabelLocalizationXml.InvalidPath.Error'         = 'Not a legal filesystem path: {0}' # $pathItem
+	'Import-SccLabelLocalizationXml.Processing'                = 'Processing localization data from {0}' # $fileItem
+	'Import-SccLabelLocalizationXml.Tooltip.BadCharacters'     = 'Bad character detected for {0} in language {1}: {2} | {3} | This will prevent its application. Specified string: {4}' # ($entry.ID -split "/")[-2], $language, ($characters -join ","), $entry.defaultText, $entry.LocalizedText
+	'Import-SccLabelLocalizationXml.Tooltip.TooLong'           = 'Too long tooltip detected for {0} in language {1} | {2} | The maximum length is 1000 characters, this tooltip cannot be imported! Specified string: {3}' # ($entry.ID -split "/")[-2], $language, $entry.defaultText, $entry.LocalizedText
+	'Set-SccLabelLocalization.Label.NoIdentity.Error'          = 'No label identity was specified. Please specify at least one of "-Name", "-FriendlyName" or "-Identity"' # 
+	'Set-SccLabelLocalization.Label.NotFound.Error'            = 'No label was found that matched: {0} | {1} | {2}' # $Name, $FriendlyName, $Identity
+	'Set-SccLabelLocalization.Processing'                      = 'Processing localization update for {0}' # $targetLabel.FriendlyName
+	'Set-SccLabelLocalization.Skipping.AlreadySet'             = 'Skipping update to {0}, as "-Default" was specified and {1} > {2} is already set' # $targetLabel.FriendlyName, $Type, $Language
+	'Set-SccLabelLocalization.Text.DisplayName.BadCharacters'  = 'The specified displayname for {0} ({1}) contains invalid characters: {2}. Text specified: {3}' # $targetLabel.FriendlyName, $Language, ($characters -join ","), $Text
+	'Set-SccLabelLocalization.Text.DisplayName.TooLong'        = 'The specified displayname for {0} ({1}) is too long. Maximum length is 64 characters. Text specified: {2}' # $targetLabel.FriendlyName, $Language, $Text
+	'Set-SccLabelLocalization.Text.Tooltip.BadCharacters'      = 'The specified tooltip for {0} ({1}) contains invalid characters: {2}. Text specified: {3}' # $targetLabel.FriendlyName, $Language, ($characters -join ","), $Text
+	'Set-SccLabelLocalization.Text.Tooltip.TooLong'            = 'The specified tooltip for {0} ({1}) is too long. Maximum length is 1000 characters. Text specified: {2}' # $targetLabel.FriendlyName, $Language, $Text
+	'Set-SccLabelLocalization.Updating'                        = 'Updating {1} in language {2} on {0}' # $targetLabel.FriendlyName, $Type, $Language
+	'Set-SccLabelLocalization.Updating.Bulk'                   = 'Executing bulk update of all localization changes to {0}' # $labelObject.FriendlyName
+	'Set-SccLabelLocalization.Updating.Bulk.Failed'            = 'Failed to update localization settings on {0}' # $labelObject.FriendlyName
 }

--- a/SecurityComplianceCenter/functions/Connect-SCC.ps1
+++ b/SecurityComplianceCenter/functions/Connect-SCC.ps1
@@ -82,6 +82,13 @@
 	
 	begin
 	{
+		$settings = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client\' -ErrorAction Ignore
+		if ($settings -and 0 -eq $settings.AllowBasic)
+		{
+			Write-PSFMessage -Level Warning -String 'Connect-SCC.Basic.Disabled'
+			throw 'Logon impossible, client policies prevent connection.'
+		}
+
 		if ($PSBoundParameters.TryGetValue('OutBuffer', [ref]$null))
 		{
 			$PSBoundParameters['OutBuffer'] = 1

--- a/SecurityComplianceCenter/functions/Enable-SccAuthentication.ps1
+++ b/SecurityComplianceCenter/functions/Enable-SccAuthentication.ps1
@@ -1,0 +1,51 @@
+﻿function Enable-SccAuthentication
+{
+	<#
+	.SYNOPSIS
+		Enables using modern authentication to connect to Security & Compliance Center.
+	
+	.DESCRIPTION
+		Enables using modern authentication to connect to Security & Compliance Center.
+		In some environments, policies exist that prevent the use of basic authentication for PowerShell CLIENTS.
+
+		Connect-SCC does NOT use basic authentication, but WinRM cannot tell the difference between basic authentication and modern authentication.
+		This command overrides the policy, but requires elevation ("Run as Administrator") to perform the override.
+	
+	.PARAMETER EnableException
+		This parameters disables user-friendly warnings and enables the throwing of exceptions.
+		This is less user friendly, but allows catching exceptions in calling scripts.
+	
+	.PARAMETER Confirm
+		If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+	
+	.PARAMETER WhatIf
+		If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+	
+	.EXAMPLE
+		PS C:\> Enable-SccAuthentication
+
+		Enables using modern authentication to connect to Security & Compliance Center.
+	#>
+	[CmdletBinding(SupportsShouldProcess = $true)]
+	param (
+		[switch]
+		$EnableException
+	)
+
+	process {
+		$settings = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client\' -ErrorAction Ignore
+		if (-not $settings) { return }
+		if ($settings.PSObject.Properties.Name -notcontains 'AllowBasic') { return }
+		if ($settings.AllowBasic -ne 0) { return }
+
+		if (-not (Test-PSFPowerShell -Elevated))
+		{
+			Stop-PSFFunction -String 'Enable-SccAuthentication.NotElevated' -EnableException $EnableException -Category SecurityError
+			return
+		}
+
+		Invoke-PSFProtectedCommand -ActionString 'Enable-SccAuthentication.Enabling' -Target $env:COMPUTERNAME -ScriptBlock {
+			Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client\' -Name AllowBasic -Value 1 -ErrorAction Stop
+		} -EnableException $EnableException -PSCmdlet $PSCmdlet
+	}
+}

--- a/SecurityComplianceCenter/functions/Import-SccLabelLocalizationXml.ps1
+++ b/SecurityComplianceCenter/functions/Import-SccLabelLocalizationXml.ps1
@@ -70,10 +70,25 @@
 					{
 						Write-PSFMessage -Level Warning -String 'Import-SccLabelLocalizationXml.DisplayName.TooLong' -StringValues ($entry.ID -split "/")[-2], $language, $entry.defaultText, $entry.LocalizedText
 					}
+					if ($type -eq 'DisplayName' -and $entry.LocalizedText -match $script:PatternDisplayNameValidation)
+					{
+						$characters = $entry.LocalizedText | Select-String "($script:PatternDisplayNameValidation)" -AllMatches | ForEach-Object {
+							@($_.Matches).ForEach{ $_.Groups[1].Value }
+						} | Select-Object -Unique | ForEach-Object { '"{0} (C: {1})"' -f $_, ([int][char]$_) }
+						Write-PSFMessage -Level Warning -String 'Import-SccLabelLocalizationXml.DisplayName.BadCharacters' -StringValues ($entry.ID -split "/")[-2], $language, ($characters -join ","), $entry.defaultText, $entry.LocalizedText
+					}
 					if ($type -eq 'Tooltip' -and $entry.LocalizedText.Length -gt 1000)
 					{
 						Write-PSFMessage -Level Warning -String 'Import-SccLabelLocalizationXml.Tooltip.TooLong' -StringValues ($entry.ID -split "/")[-2], $language, $entry.defaultText, $entry.LocalizedText
 					}
+					if ($type -eq 'Tooltip' -and $entry.LocalizedText -match $script:PatternTooltipValidation)
+					{
+						$characters = $entry.LocalizedText | Select-String "($script:PatternTooltipValidation)" -AllMatches | ForEach-Object {
+							@($_.Matches).ForEach{ $_.Groups[1].Value }
+						} | Select-Object -Unique | ForEach-Object { '"{0} (C: {1})"' -f $_, ([int][char]$_) }
+						Write-PSFMessage -Level Warning -String 'Import-SccLabelLocalizationXml.Tooltip.BadCharacters' -StringValues ($entry.ID -split "/")[-2], $language, ($characters -join ","), $entry.defaultText, $entry.LocalizedText
+					}
+					
 					[PSCustomObject]@{
 						Name = ($entry.ID -split "/")[-2]
 						Identity = $entry.ID.Replace("labelGroups/Sensitivity/labels/", "").Replace("subLabels/", "").Replace("/", "\") -replace '\\(DisplayName|Description)$'

--- a/SecurityComplianceCenter/functions/Set-SccLabelLocalization.ps1
+++ b/SecurityComplianceCenter/functions/Set-SccLabelLocalization.ps1
@@ -144,6 +144,19 @@
 			param (
 				$LabelObject
 			)
+
+			# Due to a change in service processing, we must only upload if all languages in both sets are filled out
+			if ($LabelObject.LS.DisplayName.Keys.Count -and $LabelObject.LS.Tooltip.Keys.Count)
+			{
+				foreach ($key in $LabelObject.LS.DisplayName.Keys) {
+					if ($key -in $LabelObject.LS.Tooltip.Keys) { continue }
+					$LabelObject.LS.Tooltip[$key] = $LabelObject.LS.Tooltip['default']
+				}
+				foreach ($key in $LabelObject.LS.Tooltip.Keys) {
+					if ($key -in $LabelObject.LS.DisplayName.Keys) { continue }
+					$LabelObject.LS.DisplayName[$key] = $LabelObject.LS.DisplayName['default']
+				}
+			}
 			
 			$dnHash = @{
 				localeKey = "displayName"

--- a/SecurityComplianceCenter/functions/Set-SccLabelLocalization.ps1
+++ b/SecurityComplianceCenter/functions/Set-SccLabelLocalization.ps1
@@ -227,11 +227,25 @@
 					{
 						Stop-PSFFunction -String 'Set-SccLabelLocalization.Text.DisplayName.TooLong' -StringValues $targetLabel.FriendlyName, $Language, $Text -EnableException $EnableException -Category InvalidArgument -Continue -ContinueLabel main -Cmdlet $PSCmdlet -Target $targetItem
 					}
+					if ($Text -match $script:PatternDisplayNameValidation)
+					{
+						$characters = $Text | Select-String "($script:PatternDisplayNameValidation)" -AllMatches | ForEach-Object {
+							@($_.Matches).ForEach{ $_.Groups[1].Value }
+						} | Select-Object -Unique | ForEach-Object { '"{0} (C: {1})"' -f $_, ([int][char]$_) }
+						Stop-PSFFunction -String 'Set-SccLabelLocalization.Text.DisplayName.BadCharacters' -StringValues $targetLabel.FriendlyName, $Language, ($characters -join ","), $Text -EnableException $EnableException -Category InvalidArgument -Continue -ContinueLabel main -Cmdlet $PSCmdlet -Target $targetItem
+					}
 				}
 				'Tooltip' {
 					if ($Text.Length -gt 1000)
 					{
 						Stop-PSFFunction -String 'Set-SccLabelLocalization.Text.Tooltip.TooLong' -StringValues $targetLabel.FriendlyName, $Language, $Text -EnableException $EnableException -Category InvalidArgument -Continue -ContinueLabel main -Cmdlet $PSCmdlet -Target $targetItem
+					}
+					if ($Text -match $script:PatternTooltipValidation)
+					{
+						$characters = $Text | Select-String "($script:PatternTooltipValidation)" -AllMatches | ForEach-Object {
+							@($_.Matches).ForEach{ $_.Groups[1].Value }
+						} | Select-Object -Unique | ForEach-Object { '"{0} (C: {1})"' -f $_, ([int][char]$_) }
+						Stop-PSFFunction -String 'Set-SccLabelLocalization.Text.Tooltip.BadCharacters' -StringValues $targetLabel.FriendlyName, $Language, ($characters -join ","), $Text -EnableException $EnableException -Category InvalidArgument -Continue -ContinueLabel main -Cmdlet $PSCmdlet -Target $targetItem
 					}
 				}
 			}

--- a/SecurityComplianceCenter/internal/scripts/variables.ps1
+++ b/SecurityComplianceCenter/internal/scripts/variables.ps1
@@ -1,1 +1,2 @@
-﻿
+﻿$script:PatternDisplayNameValidation = '[\\<>%&:;?/+|]'
+$script:PatternTooltipValidation = '[\x00\x08\x0B\x0C\x0E-\x1F]'


### PR DESCRIPTION
- New: Command Enable-SccAuthentication - configures WinRM to allow modern authentication when policies forbid the use of basic authentication.
- Upd: Import-SccLabelLocalizationXml - added validation for invalid characters among the imported XML.
- Upd: Set-SccLabelLocalization - added input validation for invalid characters
- Upd: Connect-SCC - added detection for disabled basic auth in WinRM client